### PR TITLE
Improve YouTube transcript retrieval with yt-dlp fallback

### DIFF
--- a/example_credentials.env
+++ b/example_credentials.env
@@ -1,3 +1,8 @@
 OPENAI_API_KEY=sk-proj-lajkhsdgf9a7wegf0q76wegf0q76wegf  # Add your OpenAI API key to this
 
 # Make a version of this in the root folder called ".env"
+
+# Optional YouTube transcript settings
+# YOUTUBE_COOKIES=/path/to/cookies.txt
+# HTTPS_PROXY=http://127.0.0.1:8888
+# YOUTUBE_LANGS=en,en-GB,en-US

--- a/src/youtube_transcript.py
+++ b/src/youtube_transcript.py
@@ -9,10 +9,10 @@
 
 from __future__ import annotations
 
-import json
 import logging
-import re
+import re as _re
 import sqlite3
+import urllib.request
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
@@ -27,6 +27,11 @@ from youtube_transcript_api._errors import (
     VideoUnavailable,
     NoTranscriptFound,
 )
+
+try:
+    from yt_dlp import YoutubeDL  # optional fallback
+except Exception:  # pragma: no cover
+    YoutubeDL = None  # type: ignore
 
 # ── local imports ─────────────────────────────────────────────────────────
 from config import settings, ensure_dirs_exist
@@ -93,9 +98,9 @@ def extract_video_id(youtube_url: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-# Modified fetch_transcript function for youtube_transcript.py
-
-def fetch_transcript(video_id: str, languages: Optional[List[str]] = None) -> Tuple[List[Dict[str, Any]], str]:
+def fetch_transcript(
+    video_id: str, languages: Optional[List[str]] = None
+) -> Tuple[List[Dict[str, Any]], str]:
     """
     Download the transcript for *video_id*, using whatever language is available if preferred
     languages aren't found.
@@ -105,21 +110,37 @@ def fetch_transcript(video_id: str, languages: Optional[List[str]] = None) -> Tu
     video_id : str
         11-character YouTube ID.
     languages : list[str] | None
-        Preferred language codes (defaults to ``["en"]``). If not available,
-        will attempt to use any available transcript.
+        Preferred language codes. If not available, will attempt to use any available transcript.
 
     Returns
     -------
     tuple[list[dict[str, Any]], str]
         Raw segments as returned by *youtube-transcript-api* and language code.
     """
-    languages = languages or ["en"]
+
+    # 1) preferred languages (from config) → then try "any available"
+    languages = languages or settings.youtube_languages or ["en", "en-GB", "en-US"]
     transcript_language = "unknown"
 
     try:
-        # First try to get transcript in preferred languages
-        transcript = YouTubeTranscriptApi.get_transcript(video_id, languages=languages)
-        transcript_language = languages[0]  # Use the first requested language if successful
+        # Build proxies/cookies args if provided
+        proxies = {"https": settings.https_proxy} if settings.https_proxy else None
+        cookies = (
+            str(settings.youtube_cookies_path)
+            if settings.youtube_cookies_path
+            else None
+        )
+
+        # First: try to get transcript in preferred languages (manual or generated)
+        transcript = YouTubeTranscriptApi.get_transcript(
+            video_id,
+            languages=languages,
+            proxies=proxies,
+            cookies=cookies,
+        )
+        transcript_language = languages[
+            0
+        ]  # Use the first requested language if successful
         return transcript, transcript_language
 
     except (TranscriptsDisabled, VideoUnavailable) as exc:
@@ -129,76 +150,205 @@ def fetch_transcript(video_id: str, languages: Optional[List[str]] = None) -> Tu
     except NoTranscriptFound:
         # If preferred languages aren't available, try to get a list of available languages
         try:
-            transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+            proxies = {"https": settings.https_proxy} if settings.https_proxy else None
+            cookies = (
+                str(settings.youtube_cookies_path)
+                if settings.youtube_cookies_path
+                else None
+            )
+            transcript_list = YouTubeTranscriptApi.list_transcripts(
+                video_id,
+                proxies=proxies,
+                cookies=cookies,
+            )
 
             # Log available languages for debug purposes
-            available_langs = [f"{t.language_code} ({t.language})" for t in transcript_list]
+            available_langs = [
+                f"{t.language_code} ({t.language})" for t in transcript_list
+            ]
             logger.info("Available transcripts for %s: %s", video_id, available_langs)
 
-            # Get the first available transcript (generated or manual)
-            # TranscriptList is an iterable, not subscriptable
+            # Prefer manual, then generated, then "first available"
+            try:
+                manual = transcript_list.find_manually_created_transcript(
+                    settings.youtube_languages
+                )
+                return manual.fetch(), manual.language_code
+            except Exception:
+                pass
+            try:
+                auto = transcript_list.find_generated_transcript(
+                    settings.youtube_languages
+                )
+                return auto.fetch(), auto.language_code
+            except Exception:
+                pass
+
+            # Otherwise iterate all and take the first one we can parse
             for transcript_obj in transcript_list:
-                logger.info("Using transcript in %s (%s)", transcript_obj.language, transcript_obj.language_code)
-                # The fetch() method returns a FetchedTranscriptSnippet object which is not a list
-                # We need to convert it to a list of dictionaries
+                logger.info(
+                    "Using transcript in %s (%s)",
+                    transcript_obj.language,
+                    transcript_obj.language_code,
+                )
                 fetched_transcript = transcript_obj.fetch()
 
-                # Convert the FetchedTranscriptSnippet to a list of dictionaries
-                # This assumes FetchedTranscriptSnippet is an iterable of transcript segments
-                transcript_data = []
-                try:
-                    # Try to iterate through the fetched transcript
-                    for segment in fetched_transcript:
-                        # Each segment should be a dictionary with start, duration, and text keys
-                        if isinstance(segment, dict):
-                            transcript_data.append(segment)
-                        else:
-                            # If segment is not a dict, try to convert it
-                            try:
-                                segment_dict = {
-                                    'text': str(getattr(segment, 'text', '')),
-                                    'start': float(getattr(segment, 'start', 0.0)),
-                                    'duration': float(getattr(segment, 'duration', 0.0))
-                                }
-                                transcript_data.append(segment_dict)
-                            except Exception as e:
-                                logger.warning(f"Could not convert segment to dict: {e}")
-                                continue
-                except Exception as e:
-                    logger.warning(f"Error iterating through transcript: {e}")
-                    # If iteration fails, try to access attributes directly
-                    if hasattr(fetched_transcript, 'get_transcript_data'):
-                        # Some APIs might have a get_transcript_data method
-                        transcript_data = fetched_transcript.get_transcript_data()
-                    else:
-                        # As a last resort, try to convert to a string and parse
-                        logger.warning("Falling back to string representation")
-                        transcript_data = [{'text': str(fetched_transcript), 'start': 0.0, 'duration': 0.0}]
+                # Normal path: `fetch()` returns a list[dict]
+                transcript_data = (
+                    list(fetched_transcript)
+                    if not isinstance(fetched_transcript, list)
+                    else fetched_transcript
+                )
 
                 # If we successfully parsed any transcript data, return it
                 if transcript_data:
                     return transcript_data, transcript_obj.language_code
                 else:
-                    logger.warning(f"Could not extract transcript data from {transcript_obj.language_code}")
+                    logger.warning(
+                        f"Could not extract transcript data from {transcript_obj.language_code}"
+                    )
                     continue
 
             # If we get here, there were no transcripts in the list or none could be parsed
-            raise NoTranscriptFound(video_id, languages, f"No transcripts found in list for video {video_id}")
+            raise NoTranscriptFound(
+                video_id,
+                languages,
+                f"No transcripts found in list for video {video_id}",
+            )
 
         except Exception as exc:
-            logger.error("Failed to fetch any transcript for %s: %s", video_id, exc)
-            raise NoTranscriptFound(video_id, languages, f"No transcripts available for video {video_id}") from exc
+            logger.error(
+                "Failed to fetch any transcript for %s via API list: %s", video_id, exc
+            )
+            # ↓ Fall through to yt-dlp fallback before giving up
+            return _fallback_with_ytdlp(video_id)
 
     # Broken captions sometimes surface as XML parse failures
     except ParseError as exc:
         msg = f"No transcript available or parse failure for video {video_id}"
         logger.error("%s – %s", msg, exc)
-        raise NoTranscriptFound(video_id, languages, msg) from exc
+        # Try yt-dlp last
+        return _fallback_with_ytdlp(video_id)
 
     # Anything we didn't anticipate
     except Exception as exc:  # noqa: BLE001
         logger.exception("Unexpected error fetching transcript for %s", video_id)
-        raise
+        return _fallback_with_ytdlp(video_id)
+
+
+# ---------------------- yt-dlp fallback ------------------------------------
+
+
+def _fallback_with_ytdlp(video_id: str) -> Tuple[List[Dict[str, Any]], str]:
+    """
+    Last-resort: use yt-dlp to obtain subtitles (manual or automatic) and
+    convert VTT → segment list. Requires yt-dlp to be installed.
+    """
+    if YoutubeDL is None:
+        raise NoTranscriptFound(video_id, [], "yt-dlp not available and API failed")
+
+    url = f"https://www.youtube.com/watch?v={video_id}"
+    langs = settings.youtube_languages
+    ydl_opts = {
+        "skip_download": True,
+        "writesubtitles": True,
+        "writeautomaticsub": True,
+        "subtitlesformat": "vtt",
+        "subtitleslangs": langs,
+        "quiet": True,
+        "no_warnings": True,
+    }
+
+    try:
+        with YoutubeDL(ydl_opts) as ydl:
+            info = ydl.extract_info(url, download=False)
+    except Exception as exc:
+        raise NoTranscriptFound(
+            video_id, langs, f"yt-dlp extraction failed: {exc}"
+        ) from exc
+
+    subs = info.get("subtitles") or {}
+    autos = info.get("automatic_captions") or {}
+
+    # Pick the first language that exists in subs or autos
+    chosen_lang = None
+    tracks = None
+    for code in langs:
+        if code in subs:
+            chosen_lang, tracks = code, subs[code]
+            break
+        if code in autos:
+            chosen_lang, tracks = code, autos[code]
+            break
+    if not tracks:  # nothing in preferred langs; try any
+        sources = subs or autos
+        if sources:
+            chosen_lang, tracks = next(iter(sources.items()))
+    if not tracks:
+        raise NoTranscriptFound(video_id, langs, "yt-dlp found no captions")
+
+    # Grab first VTT URL and fetch it
+    vtt_url = None
+    for t in tracks:
+        if t.get("ext") == "vtt" and t.get("url"):
+            vtt_url = t["url"]
+            break
+    if not vtt_url:
+        vtt_url = tracks[0].get("url")
+    if not vtt_url:
+        raise NoTranscriptFound(video_id, langs, "yt-dlp captions had no URL")
+
+    try:
+        with urllib.request.urlopen(vtt_url) as resp:
+            vtt_text = resp.read().decode("utf-8", errors="replace")
+    except Exception as exc:
+        raise NoTranscriptFound(
+            video_id, langs, f"Failed to download VTT: {exc}"
+        ) from exc
+
+    segments = _vtt_to_segments(vtt_text)
+    if not segments:
+        raise NoTranscriptFound(video_id, langs, "VTT parsed to zero segments")
+    logger.info("yt-dlp fallback succeeded for %s (%s)", video_id, chosen_lang)
+    return segments, chosen_lang or "unknown"
+
+
+def _vtt_to_segments(vtt_text: str) -> List[Dict[str, Any]]:
+    """
+    Very small VTT → segments converter: returns [{'text','start','duration'}, ...]
+    Assumes well-formed cue timings like '00:01.234 --> 00:03.000'
+    """
+
+    def _ts_to_seconds(ts: str) -> float:
+        # hh:mm:ss.mmm or mm:ss.mmm
+        parts = ts.split(":")
+        if len(parts) == 3:
+            h, m, s = parts
+            return int(h) * 3600 + int(m) * 60 + float(s.replace(",", "."))
+        m, s = parts
+        return int(m) * 60 + float(s.replace(",", "."))
+
+    segments: List[Dict[str, Any]] = []
+    # split on blank lines to get cues
+    for block in _re.split(r"\n\s*\n", vtt_text.strip()):
+        lines = [ln.strip() for ln in block.splitlines() if ln.strip()]
+        if len(lines) < 2:
+            continue
+        # optional cue id at lines[0]; timings line contains '-->'
+        timing_idx = 0 if "-->" in lines[0] else 1
+        if "-->" not in lines[timing_idx]:
+            continue
+        start_s, end_s = [x.strip() for x in lines[timing_idx].split("-->")[:2]]
+        text = " ".join(lines[timing_idx + 1 :])
+        try:
+            start = _ts_to_seconds(start_s)
+            end = _ts_to_seconds(end_s)
+            segments.append(
+                {"text": text, "start": start, "duration": max(0.0, end - start)}
+            )
+        except Exception:
+            continue
+    return segments
 
 
 # ---------------------------------------------------------------------------
@@ -275,12 +425,12 @@ def _transcript_exists(conn: sqlite3.Connection, video_id: str) -> bool:
 
 
 def save_transcript(
-        transcript: List[Dict[str, Any]],
-        video_id: str,
-        video_title: Optional[str] = None,
-        channel_name: Optional[str] = None,
-        transcript_language: Optional[str] = None,
-        overwrite: bool = False,
+    transcript: List[Dict[str, Any]],
+    video_id: str,
+    video_title: Optional[str] = None,
+    channel_name: Optional[str] = None,
+    transcript_language: Optional[str] = None,
+    overwrite: bool = False,
 ) -> Tuple[Path, bool]:
     """
     Persist transcript to a nicely-named text file **and** SQLite.
@@ -317,7 +467,9 @@ def save_transcript(
 
     # Verify we have a valid transcript list to work with
     if not isinstance(transcript, list):
-        logger.warning(f"Transcript is not a list but a {type(transcript)}, attempting to convert...")
+        logger.warning(
+            f"Transcript is not a list but a {type(transcript)}, attempting to convert..."
+        )
         try:
             # Try to convert to a list if it's iterable
             transcript_list = list(transcript)
@@ -325,11 +477,13 @@ def save_transcript(
         except Exception as e:
             logger.error(f"Failed to convert transcript to list: {e}")
             # Create a simple list with just the string representation
-            transcript = [{'text': str(transcript), 'start': 0.0, 'duration': 0.0}]
+            transcript = [{"text": str(transcript), "start": 0.0, "duration": 0.0}]
 
     if not transcript:
         logger.warning("Empty transcript received, creating placeholder")
-        transcript = [{'text': "[No transcript content available]", 'start': 0.0, 'duration': 0.0}]
+        transcript = [
+            {"text": "[No transcript content available]", "start": 0.0, "duration": 0.0}
+        ]
 
     # Ensure all transcript items are dictionaries with the required keys
     for i, item in enumerate(transcript):
@@ -338,20 +492,20 @@ def save_transcript(
             try:
                 # Try to convert to dict if it has the necessary attributes
                 transcript[i] = {
-                    'text': str(getattr(item, 'text', str(item))),
-                    'start': float(getattr(item, 'start', 0.0)),
-                    'duration': float(getattr(item, 'duration', 0.0))
+                    "text": str(getattr(item, "text", str(item))),
+                    "start": float(getattr(item, "start", 0.0)),
+                    "duration": float(getattr(item, "duration", 0.0)),
                 }
             except Exception as e:
                 logger.error(f"Failed to convert transcript item to dict: {e}")
-                transcript[i] = {'text': str(item), 'start': 0.0, 'duration': 0.0}
-        elif 'text' not in item:
+                transcript[i] = {"text": str(item), "start": 0.0, "duration": 0.0}
+        elif "text" not in item:
             logger.warning(f"Transcript item {i} missing 'text' key: {item}")
-            transcript[i]['text'] = str(item)
+            transcript[i]["text"] = str(item)
 
     # ---------- write text file ------------------------------------------------
     safe_id = video_id.replace("/", "_").replace("\\", "_")
-    safe_title = re.sub(r"[^\w\s-]", "", video_title).replace(" ", "_")[:60]
+    safe_title = _re.sub(r"[^\w\s-]", "", video_title).replace(" ", "_")[:60]
     out_file = settings.transcripts_dir / f"transcript_{safe_id}_{safe_title}.txt"
 
     try:
@@ -379,7 +533,9 @@ def save_transcript(
 
         # Extract transcript text safely
         try:
-            transcript_text = "\n".join(segment.get('text', '') for segment in transcript)
+            transcript_text = "\n".join(
+                segment.get("text", "") for segment in transcript
+            )
         except Exception as e:
             logger.error(f"Error extracting transcript text: {e}")
             transcript_text = "[Error extracting transcript text]"
@@ -402,7 +558,11 @@ def save_transcript(
         )
         conn.commit()
         saved = True
-        logger.info("Transcript stored in DB (video_id=%s, language=%s)", video_id, transcript_language)
+        logger.info(
+            "Transcript stored in DB (video_id=%s, language=%s)",
+            video_id,
+            transcript_language,
+        )
 
     return out_file, saved
 
@@ -426,7 +586,7 @@ def _interactive_flow() -> None:
 
     print("Fetching transcript… (this might take a few seconds)")
     try:
-        transcript = fetch_transcript(vid)
+        transcript, transcript_language = fetch_transcript(vid)
     except Exception as exc:  # noqa: BLE001
         print(f"Failed to fetch transcript: {exc}")
         return
@@ -444,10 +604,13 @@ def _interactive_flow() -> None:
         video_id=vid,
         video_title=title_override or None,
         channel_name=channel_override or None,
+        transcript_language=transcript_language,
     )
 
     print(f"Transcript saved to file: {out}")
-    print("Transcript also saved to database." if inserted else "Already existed in DB.")
+    print(
+        "Transcript also saved to database." if inserted else "Already existed in DB."
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- handle consent/region issues by allowing cookies and proxy configuration
- fall back to yt-dlp subtitles when YouTube API transcripts are unavailable
- document optional YouTube transcript environment variables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0733da1408324845f7e92e5b9d5a6